### PR TITLE
fix "Prefer `format()` over `%`  for string interpolation" issue

### DIFF
--- a/test.py
+++ b/test.py
@@ -6,7 +6,7 @@ def test(a, b=[]):
 
 id = "testing"
 variable = "testing"
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
@@ -16,94 +16,94 @@ exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")

--- a/test/subfolder/zack.py
+++ b/test/subfolder/zack.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 variable = "testing"
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
@@ -10,93 +10,93 @@ exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")

--- a/test/test.py
+++ b/test/test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
@@ -14,87 +14,87 @@ exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)

--- a/test/test3.py
+++ b/test/test3.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 variable = "testing"
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
@@ -10,93 +10,93 @@ exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")

--- a/test3.py
+++ b/test3.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over `%`  for string interpolation](http://localhost:5000/app/issue_class/4ACGxFj1)
Issue details: [http://localhost:5000/app/project/gh:programmdesign:qc-test?groups=code_patterns/%3A4ACGxFj1](http://localhost:5000/app/project/gh:programmdesign:qc-test?groups=code_patterns/%3A4ACGxFj1)

I do not claim any copyright on the changes.
If you need to adjust the commit messages or the individual changes, feel free to rebase, cherry-pick or do whatever you consider appropriate with my commits.
For questions, feedback or small talk you can contact me at cody@quantifiedcode.com.

Cheers,
[Cody](https://www.quantifiedcode.com/cody)
