### PR TITLE
Fix "Prefer `format()` over `%`  for string interpolation" issue

### DIFF
--- a/test.py
+++ b/test.py
@@ -6,7 +6,7 @@ def test(a, b=[]):
 
 id = "testing"
 variable = "testing"
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
@@ -16,94 +16,94 @@ exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")

--- a/test/subfolder/zack.py
+++ b/test/subfolder/zack.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 variable = "testing"
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
@@ -10,93 +10,93 @@ exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")

--- a/test/test.py
+++ b/test/test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
@@ -14,87 +14,87 @@ exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)

--- a/test/test3.py
+++ b/test/test3.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 variable = "testing"
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
@@ -10,93 +10,93 @@ exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
-eval("print variable")
-variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
-exec(variable)
-eval(varialbe)
-eval(variable)
-eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
+eval("print variable")
+eval("print variable")
+variable = "testing"
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
+exec(variable)
+eval(varialbe)
+eval(variable)
+eval("print variable")
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 eval("print variable")

--- a/test3.py
+++ b/test3.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over `%`  for string interpolation](http://localhost:5000/app/issue_class/4ACGxFj1)
Issue details: [http://localhost:5000/app/project/gh:programmdesign:qc-test?groups=code_patterns/%3A4ACGxFj1](http://localhost:5000/app/project/gh:programmdesign:qc-test?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
