### PR TITLE
Fix "Consider using a set comprehensions instead of passing a list to `set()`" issue

### DIFF
--- a/test.py
+++ b/test.py
@@ -16,7 +16,7 @@ times.append({"hour": 8, "minute": 37, "second": 05, "hour": 12})
 times.append({"hour": 9, "minute": 37, "second": 05, "hour": 12})
 
 stuff_dict = dict([(t["minute"], t["hour"]) for t in times])
-stuff_set = set([t["hour"] for t in times])
+stuff_set = {t["hour"] for t in times}
 
 some_list = None
 if not some_list is None:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider using a set comprehensions instead of passing a list to `set()`](http://localhost:5000/app/issue_class/2e5IzmR1)
Issue details: [http://localhost:5000/app/project/gh:programmdesign:qc-test?groups=code_patterns/%3A2e5IzmR1](http://localhost:5000/app/project/gh:programmdesign:qc-test?groups=code_patterns/%3A2e5IzmR1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
