### PR TITLE
Fix "`not ... is` used instead of `is not`" issue

### DIFF
--- a/test.py
+++ b/test.py
@@ -33,7 +33,7 @@ if i <> k:
     print("Unequal")
   
 x = None
-if x == None:
+if x is None:
   print "Ouch"
 
 id = "testing"


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [`not ... is` used instead of `is not`](http://localhost:5000/app/issue_class/4ORGpHyx)
Issue details: [http://localhost:5000/app/project/gh:programmdesign:qc-test?groups=code_patterns/%3A4ORGpHyx](http://localhost:5000/app/project/gh:programmdesign:qc-test?groups=code_patterns/%3A4ORGpHyx)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
